### PR TITLE
fixed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ This plugin allows Jarvis launch at startup and monitoring for systemd distribut
 
 ## Usage
 Once Jarvis is started by `systemd`, you can:
-- Connect to Jarvis thanks to `./jarvis.sh` then select `Show Jarvis output`
 - See Jarvis output thanks to `sudo journalctl -u jarvis.service`
 - Stop Jarvis thanks to `sudo service jarvis stop` or `jarvis.sh -q`
 - Start Jarvis again thanks to `sudo service jarvis restart`
+
+Note:
+- Selecting `Show Jarvis output` when using `./jarvis.sh` won't display Jarvis output. Please use above method instead.
 
 ## Author
 [Oliv4945](https://iopush.net)


### PR DESCRIPTION
As discussed, Jarvis Output won't show anything unless you `tee` manually the output to /home/pi/jarvis/jarvis.log.